### PR TITLE
Fixes module purviews and compilation IDs

### DIFF
--- a/projs/shadow-engine/shadow-engine.cpp
+++ b/projs/shadow-engine/shadow-engine.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <SDL.h>
-#include <glm.hpp>
+#include <glm/glm.hpp>
 
 // You must include the command line parameters for your main function to be recognized by SDL
 int main(int argc, char** args) {

--- a/projs/shadow-file-format/shadow-file-format.vcxproj
+++ b/projs/shadow-file-format/shadow-file-format.vcxproj
@@ -24,16 +24,19 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="src/SFFElement.cpp" />
-    <ClCompile Include="src/SFFParser.cpp" />
-
-    <ClCompile Include="src/SFFElement.ixx" />
+    <ClCompile Include="src/SFFElement.cpp">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="src/SFFParser.cpp">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="src/SFFElement.ixx">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCppModule</CompileAs>
+    </ClCompile>
     <ClCompile Include="src/Shadow.FileFormat.ixx" />
     <ClCompile Include="src/SFFParser.ixx" />
     <ClCompile Include="src/SFFVersion.ixx" />
-
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\shadow-utility\shadow-utility.vcxproj">
       <Project>{7b9e6056-e4fb-411b-9612-a2fd679c2b69}</Project>

--- a/projs/shadow-file-format/shadow-file-format.vcxproj.filters
+++ b/projs/shadow-file-format/shadow-file-format.vcxproj.filters
@@ -21,25 +21,18 @@
     <ClCompile Include="src/**/*.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src/**/*.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="src/SFFElement.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src/SFFParser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="SFFElement.ixx" />
-    <ClCompile Include="Shadow.FileFormat.ixx" />
+    <ClCompile Include="src/SFFElement.ixx" />
+    <ClCompile Include="src/Shadow.FileFormat.ixx" />
+    <ClCompile Include="src/SFFParser.ixx" />
+    <ClCompile Include="src/SFFVersion.ixx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="src\SFFParser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="src\SFFVersion.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="src/**/*.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -53,12 +46,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src/**/*.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="src/SFFParser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="src/SFFVersion.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/projs/shadow-file-format/src/SFFElement.cpp
+++ b/projs/shadow-file-format/src/SFFElement.cpp
@@ -1,15 +1,37 @@
-﻿/*
-module;
+﻿module;
+
+import <string>;
+
+import shadow_utils;
 
 module Shadow.FileFormat:SFFElement;
 
-import <string>;
-import shadow_utils;
 
 namespace Shadow::SFF {
 
 
+    SFFElement* SFFElement::GetFirstChild()
+    {
+        return children.size() > 0 ? children.begin()->second : nullptr;
+    }
 
+    SFFElement* SFFElement::GetChildByIndex(int index)
+    {
+        ChildrenMap::iterator it = children.begin();
+        for (size_t i = 0; i < index; i++)
+        {
+            it++;
+        }
+        return it->second;
+    }
+
+    SFFElement* SFFElement::GetChildByName(std::string name)
+    {
+        ChildrenMap::iterator it = children.find(name);
+        if (it != children.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
 
 }
-*/

--- a/projs/shadow-file-format/src/SFFElement.cpp
+++ b/projs/shadow-file-format/src/SFFElement.cpp
@@ -1,11 +1,10 @@
 ﻿module;
 
+module Shadow.FileFormat:SFFElement;
+
 import <string>;
 
 import shadow_utils;
-
-module Shadow.FileFormat:SFFElement;
-
 
 namespace Shadow::SFF {
 

--- a/projs/shadow-file-format/src/SFFElement.ixx
+++ b/projs/shadow-file-format/src/SFFElement.ixx
@@ -1,11 +1,10 @@
 module;
 
+export module Shadow.FileFormat:SFFElement;
+
 import <string>;
 import <map>;
 import <list>;
-
-export module Shadow.FileFormat:SFFElement;
-
 
 export namespace Shadow::SFF {
 

--- a/projs/shadow-file-format/src/SFFElement.ixx
+++ b/projs/shadow-file-format/src/SFFElement.ixx
@@ -1,14 +1,15 @@
 module;
 
-export module Shadow.FileFormat:SFFElement;
-
 import <string>;
 import <map>;
 import <list>;
 
- namespace Shadow::SFF {
+export module Shadow.FileFormat:SFFElement;
 
-    export class SFFElement
+
+export namespace Shadow::SFF {
+
+	class SFFElement
 	{
 	public:
 		SFFElement* parent;
@@ -25,29 +26,12 @@ import <list>;
 
 		std::string GetStringProperty(std::string name);
 
-        SFFElement* GetFirstChild()
-        {
-            return children.size() > 0 ? children.begin()->second : nullptr;
-        }
 
-        SFFElement* GetChildByIndex(int index)
-        {
-            ChildrenMap::iterator it = children.begin();
-            for (size_t i = 0; i < index; i++)
-            {
-                it++;
-            }
-            return it->second;
-        }
+        SFFElement* GetFirstChild();
 
-        SFFElement* GetChildByName(std::string name)
-        {
-            ChildrenMap::iterator it = children.find(name);
-            if (it != children.end()) {
-                return it->second;
-            }
-            return nullptr;
-        }
+		SFFElement* GetChildByIndex(int index);
+
+		SFFElement* GetChildByName(std::string name);
 
 		~SFFElement();
 

--- a/projs/shadow-file-format/src/SFFParser.cpp
+++ b/projs/shadow-file-format/src/SFFParser.cpp
@@ -1,15 +1,17 @@
 module;
-import <string>;
-import <iostream>;
-import <string>;
 
-import shadow_utils;
+#include <fstream>
 
 module Shadow.FileFormat:SFFParser;
 
 import :SFFElement;
 import :SFFVersion;
 
+import <string>;
+import <iostream>;
+import <string>;
+
+import shadow_utils;
 
 namespace Shadow::SFF {
 

--- a/projs/shadow-file-format/src/SFFParser.cpp
+++ b/projs/shadow-file-format/src/SFFParser.cpp
@@ -1,4 +1,3 @@
-/*
 module;
 import <string>;
 import <iostream>;
@@ -14,5 +13,112 @@ import :SFFVersion;
 
 namespace Shadow::SFF {
 
+	SFFElement* SFFParser::ReadFromStream(std::istream& stream)
+	{
+		auto version = ReadVersionFromHeader(stream);
+		if (version.invalid) {
+			//SH_CORE_WARN("Shadow File is invalid");
+			return nullptr;
+		}
+
+
+		//The current node that we are building
+		auto* context = new SFFElement;
+
+		//Top level Element
+		SFFElement* base = context;
+
+		//The new node that will be a child of the context
+		auto* current = new SFFElement;
+
+
+		std::string buffer;
+
+		char c;
+		while (!stream.eof())
+		{
+			stream.get(c);
+			if (c == ':')
+			{
+				//The stuff in the buffer is a parameter name
+				std::cout << "Name: " << buffer;
+				current->name = buffer;
+				buffer = "";
+			}
+			else if (c == '{')
+			{
+				//Start of a new block
+				current->isBlock = true;
+				current->parent = context;
+				context->children[current->name] = current;
+				context = current;
+
+				current = new SFFElement;
+			}
+			else if (c == ',')
+			{
+				// End of a property
+				//The stuff is the value
+				std::cout << "Value: " << buffer << std::endl;
+				current->value = buffer;
+				current->parent = context;
+				current->isBlock = false;
+				buffer = "";
+
+				context->children[current->name] = current;
+
+				current = new SFFElement();
+			}
+			else if (c == '}')
+			{
+				// End of a block
+				context = context->parent;
+			}
+			else
+			{
+				if (std::isspace(c) == 0)
+				{
+					buffer += c;
+				}
+			}
+		}
+
+		std::cout << "END" << std::endl;
+
+		return base;
+	}
+
+	SFFVersion SFFParser::ReadVersionFromHeader(std::istream& stream) {
+		std::string line;
+		std::getline(stream, line);
+		auto parts = explode(line, '_');
+		if (parts[0] != "ShadowFileFormat") {
+			return SFFVersion(-1,-1,-1);
+		}
+		else {
+			int mayor = std::stoi(parts[1]);
+			int minor = std::stoi(parts[2]);
+			int patch = std::stoi(parts[3]);
+			return SFFVersion(mayor, minor, patch);
+		}
+		
+	}
+
+
+
+	SFFElement* SFFParser::ReadFromFile(std::string path)
+	{
+		std::ifstream inputFileStream(path);
+
+		if (errno)
+		{
+			//SH_CORE_ERROR("Error: {0} | File: {1}", strerror(errno), path);
+			//std::cerr << "Error: " << strerror(errno) << std::endl;
+			//std::cerr << "File: " << path << std::endl;
+			return nullptr;
+		}
+
+		return ReadFromStream(inputFileStream);
+	}
+
 }
-*/

--- a/projs/shadow-file-format/src/SFFParser.ixx
+++ b/projs/shadow-file-format/src/SFFParser.ixx
@@ -1,130 +1,24 @@
 module;
 
-export module Shadow.FileFormat:SFFParser;
-
 import <string>;
 import <iostream>;
-import <fstream>;
-import <string>;
-import shadow_utils;
+
+export module Shadow.FileFormat:SFFParser;
 
 import :SFFElement;
 import :SFFVersion;
 
-namespace Shadow::SFF {
+export namespace Shadow::SFF {
 
-	export class SFFParser
+	class SFFParser
 	{
 	public:
 
-		static SFFElement* ReadFromStream(std::istream& stream)
-		{
-			auto version = ReadVersionFromHeader(stream);
-			if (version.invalid) {
-				//SH_CORE_WARN("Shadow File is invalid");
-				return nullptr;
-			}
+		static SFFElement* ReadFromStream(std::istream& stream);
 
+		static SFFVersion ReadVersionFromHeader(std::istream& stream);
 
-			//The current node that we are building
-			auto* context = new SFFElement;
-
-			//Top level Element
-			SFFElement* base = context;
-
-			//The new node that will be a child of the context
-			auto* current = new SFFElement;
-
-
-			std::string buffer;
-
-			char c;
-			while (!stream.eof())
-			{
-				stream.get(c);
-				if (c == ':')
-				{
-					//The stuff in the buffer is a parameter name
-					std::cout << "Name: " << buffer;
-					current->name = buffer;
-					buffer = "";
-				}
-				else if (c == '{')
-				{
-					//Start of a new block
-					current->isBlock = true;
-					current->parent = context;
-					context->children[current->name] = current;
-					context = current;
-
-					current = new SFFElement;
-				}
-				else if (c == ',')
-				{
-					// End of a property
-					//The stuff is the value
-					std::cout << "Value: " << buffer << std::endl;
-					current->value = buffer;
-					current->parent = context;
-					current->isBlock = false;
-					buffer = "";
-
-					context->children[current->name] = current;
-
-					current = new SFFElement();
-				}
-				else if (c == '}')
-				{
-					// End of a block
-					context = context->parent;
-				}
-				else
-				{
-					if (std::isspace(c) == 0)
-					{
-						buffer += c;
-					}
-				}
-			}
-
-			std::cout << "END" << std::endl;
-
-			return base;
-		}
-
-		static SFFVersion ReadVersionFromHeader(std::istream& stream) {
-			std::string line;
-			std::getline(stream, line);
-			auto parts = explode(line, '_');
-			if (parts[0] != "ShadowFileFormat") {
-				return SFFVersion(-1, -1, -1);
-			}
-			else {
-				int mayor = std::stoi(parts[1]);
-				int minor = std::stoi(parts[2]);
-				int patch = std::stoi(parts[3]);
-				return SFFVersion(mayor, minor, patch);
-			}
-
-		}
-
-
-
-		static SFFElement* ReadFromFile(std::string path)
-		{
-			std::ifstream inputFileStream(path);
-
-			if (errno)
-			{
-				//SH_CORE_ERROR("Error: {0} | File: {1}", strerror(errno), path);
-				//std::cerr << "Error: " << strerror(errno) << std::endl;
-				//std::cerr << "File: " << path << std::endl;
-				return nullptr;
-			}
-
-			return ReadFromStream(inputFileStream);
-		}
-
+		static SFFElement* ReadFromFile(std::string path);
 	};
 
 }

--- a/projs/shadow-file-format/src/SFFParser.ixx
+++ b/projs/shadow-file-format/src/SFFParser.ixx
@@ -1,9 +1,9 @@
 module;
 
+export module Shadow.FileFormat:SFFParser;
+
 import <string>;
 import <iostream>;
-
-export module Shadow.FileFormat:SFFParser;
 
 import :SFFElement;
 import :SFFVersion;

--- a/projs/shadow-utility/shadow-utility.vcxproj
+++ b/projs/shadow-utility/shadow-utility.vcxproj
@@ -33,7 +33,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="shadow-utils.ixx" />
-    <ClCompile Include="string-helpers.cpp" />
+    <ClCompile Include="string-helpers.cpp">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/projs/shadow-utility/string-helpers.cpp
+++ b/projs/shadow-utility/string-helpers.cpp
@@ -1,9 +1,9 @@
 module;
 
-module shadow_utils;
-
 import <string>;
 import <vector>;
+
+module shadow_utils;
 
 inline std::vector<std::string> explode(const std::string& s, const char& c)
 {

--- a/projs/shadow-utility/string-helpers.cpp
+++ b/projs/shadow-utility/string-helpers.cpp
@@ -1,9 +1,10 @@
 module;
 
-import <string>;
-import <vector>;
+#include <string>
+#include <vector>
 
 module shadow_utils;
+
 
 inline std::vector<std::string> explode(const std::string& s, const char& c)
 {


### PR DESCRIPTION
Module global fragments can only contain preprocessor directives, so move all imported modules out of it.
module;
// this is the global module fragment
export module Blahblah;

// All of your imports here

Or like this:
module;
// this is the global module fragment
module Blahblah;

// All of your imports here

The file compilation identifiers for modules for SFFParser.cpp, string_helpers.cpp, and SFFElement.cpp were all changed to (/TP or Compile As C++ Code).

Other changes were made to reflect my system (<glm/glm.hpp> vs <glm.hpp>) and a missing #include <fstream> was also added.
