### PR TITLE
Fix DLL loading

### DIFF
--- a/projs/shadow/shadow-engine/core/inc/core/Module.h
+++ b/projs/shadow/shadow-engine/core/inc/core/Module.h
@@ -2,6 +2,7 @@
 #define UMBRA_MODULE_H
 
 #include "SHObject.h"
+#include <SDL_events.h>
 
 namespace ShadowEngine {
 
@@ -30,11 +31,17 @@ namespace ShadowEngine {
         /// </summary>
         virtual void Update() = 0;
 
+        virtual void PreRender() = 0;
+
         virtual void Render() = 0;
 
         virtual void LateRender() = 0;
 
         virtual void AfterFrameEnd() = 0;
+
+        virtual void Destroy() = 0;
+
+        virtual void Event(SDL_Event* e) = 0;
 
         /// <summary>
         /// Returns the name of the module

--- a/projs/shadow/shadow-engine/core/inc/core/ModuleManager.h
+++ b/projs/shadow/shadow-engine/core/inc/core/ModuleManager.h
@@ -45,7 +45,13 @@ namespace ShadowEngine {
 
         void Render();
 
+        void PreRender();
+
         void AfterFrameEnd();
+
+        void Destroy();
+
+        void Event(SDL_Event* evt);
     };
 }
 

--- a/projs/shadow/shadow-engine/core/inc/core/SDL2Module.h
+++ b/projs/shadow/shadow-engine/core/inc/core/SDL2Module.h
@@ -32,6 +32,12 @@ namespace ShadowEngine {
         std::string GetName() override;
 
         void AfterFrameEnd() override;
+
+        void PreRender() override;
+
+        void Destroy() override;
+
+        void Event(SDL_Event* e) override;
     };
 
 }

--- a/projs/shadow/shadow-engine/core/inc/debug/DebugModule.h
+++ b/projs/shadow/shadow-engine/core/inc/debug/DebugModule.h
@@ -5,6 +5,7 @@
 #ifndef UMBRA_DEBUGMODULE_H
 #define UMBRA_DEBUGMODULE_H
 
+#include <SDL_events.h>
 #include "core/Module.h"
 
 namespace ShadowEngine::Debug {
@@ -27,6 +28,12 @@ namespace ShadowEngine::Debug {
         void LateRender() override {  };
 
         void AfterFrameEnd() override {  };
+
+        void PreRender() override { };
+
+        void Destroy() override {};
+
+        void Event(SDL_Event* e) override {};
     };
 
 }

--- a/projs/shadow/shadow-engine/core/src/core/ModuleManager.cpp
+++ b/projs/shadow/shadow-engine/core/src/core/ModuleManager.cpp
@@ -47,6 +47,31 @@ void ShadowEngine::ModuleManager::Init()
     }
 }
 
+void ShadowEngine::ModuleManager::Destroy()
+{
+    for (auto& module : modules)
+    {
+        module.module->Destroy();
+    }
+}
+
+
+void ShadowEngine::ModuleManager::PreRender()
+{
+    for (auto& module : modules)
+    {
+        module.module->PreRender();
+    }
+}
+
+void ShadowEngine::ModuleManager::Event(SDL_Event* evt)
+{
+    for (auto& module : modules)
+    {
+        module.module->Event(evt);
+    }
+}
+
 void ShadowEngine::ModuleManager::Update()
 {
     for (auto& module : modules)

--- a/projs/shadow/shadow-engine/core/src/core/SDL2Module.cpp
+++ b/projs/shadow/shadow-engine/core/src/core/SDL2Module.cpp
@@ -5,9 +5,13 @@
 #include "core/SDL2Module.h"
 #include "core/ShadowWindow.h"
 #include "spdlog/spdlog.h"
+#include "imgui_impl_sdl.h"
 
 
 void ShadowEngine::SDL2Module::Init() {
+}
+
+void ShadowEngine::SDL2Module::PreInit() {
     // Initialize SDL. SDL_Init will return -1 if it fails.
     if ( SDL_Init( SDL_INIT_EVERYTHING ) < 0 ) {
         spdlog::error("Error creating window: " + std::string(SDL_GetError()));
@@ -17,10 +21,6 @@ void ShadowEngine::SDL2Module::Init() {
     }
 
     _window = new ShadowWindow(800,450);
-}
-
-void ShadowEngine::SDL2Module::PreInit() {
-
 }
 
 void ShadowEngine::SDL2Module::Update() {
@@ -41,4 +41,16 @@ std::string ShadowEngine::SDL2Module::GetName() {
 
 void ShadowEngine::SDL2Module::AfterFrameEnd() {
 
+}
+
+void ShadowEngine::SDL2Module::Event(SDL_Event *e) {
+    ImGui_ImplSDL2_ProcessEvent(e);
+}
+
+void ShadowEngine::SDL2Module::Destroy() {
+    SDL_DestroyWindow(_window->sdlWindowPtr);
+    SDL_Quit();
+}
+
+void ShadowEngine::SDL2Module::PreRender() {
 }

--- a/projs/shadow/shadow-engine/core/src/core/ShadowApplication.cpp
+++ b/projs/shadow/shadow-engine/core/src/core/ShadowApplication.cpp
@@ -19,9 +19,6 @@
 
 namespace ShadowEngine {
 
-    // Create the renderer
-    SingleRenderer object;
-
     dylib* gameLib;
 
 	ShadowApplication* ShadowApplication::instance = nullptr;
@@ -83,183 +80,32 @@ namespace ShadowEngine {
         auto sdl2module = moduleManager.GetModuleByType<SDL2Module>();
 
         window_ = sdl2module->_window;
-
-        printf("exe side: %p \n", VulkanManager::getInstance());
-
-        CATCH(VulkanManager::getInstance()->initVulkan(window_->sdlWindowPtr);)
-
-        IMGUI_CHECKVERSION();
-        ImGui::CreateContext();
-        ImGuiIO& io = ImGui::GetIO(); (void)io;
-        io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
-        io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
-
-        // Setup Dear ImGui style
-        ImGui::StyleColorsDark();
-
-
-        VkDescriptorPool imGuiPool;
-        VulkanManager* vk = VulkanManager::getInstance();
-        VkDescriptorPoolSize pool_sizes[] =
-                {
-                        { VK_DESCRIPTOR_TYPE_SAMPLER, 1000 },
-                        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000 },
-                        { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1000 },
-                        { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1000 },
-                        { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1000 },
-                        { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1000 },
-                        { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1000 },
-                        { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1000 },
-                        { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1000 },
-                        { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1000 },
-                        { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1000 }
-                };
-
-        VkDescriptorPoolCreateInfo pool_info = {};
-        pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-        pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-        pool_info.maxSets = 1000 * IM_ARRAYSIZE(pool_sizes);
-        pool_info.poolSizeCount = (uint32_t)IM_ARRAYSIZE(pool_sizes);
-        pool_info.pPoolSizes = pool_sizes;
-        vkCreateDescriptorPool(vk->getDevice()->logical, &pool_info, VK_NULL_HANDLE, &imGuiPool);
-
-        // Setup Platform/Renderer backends
-        ImGui_ImplSDL2_InitForVulkan(window_->sdlWindowPtr);
-        ImGui_ImplVulkan_InitInfo init_info = {};
-        init_info.Instance = vk->getVulkan();
-        init_info.PhysicalDevice = vk->getDevice()->physical;
-        init_info.Device = vk->getDevice()->logical;
-        init_info.QueueFamily = vk->getDevice()->queueData.graphics;
-        init_info.Queue = vk->getDevice()->graphicsQueue;
-        init_info.PipelineCache = VK_NULL_HANDLE;
-        init_info.DescriptorPool = imGuiPool;
-        init_info.Subpass = 0;
-        init_info.MinImageCount = vk->getSwapchain()->images.size();
-        init_info.ImageCount = vk->getSwapchain()->images.size();
-        init_info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
-        init_info.Allocator = VK_NULL_HANDLE;
-        init_info.CheckVkResultFn = nullptr;
-        ImGui_ImplVulkan_Init(&init_info, vk->getRenderPass()->pass);
-
-        // Load Fonts
-        // - If no fonts are loaded, dear imgui will use the default font. You can also load multiple fonts and use ImGui::PushFont()/PopFont() to select them.
-        // - AddFontFromFileTTF() will return the ImFont* so you can store it if you need to select the font among multiple.
-        // - If the file cannot be loaded, the function will return NULL. Please handle those errors in your application (e.g. use an assertion, or display an error and quit).
-        // - The fonts will be rasterized at a given size (w/ oversampling) and stored into a texture when calling ImFontAtlas::Build()/GetTexDataAsXXXX(), which ImGui_ImplXXXX_NewFrame below will call.
-        // - Read 'docs/FONTS.md' for more instructions and details.
-        // - Remember that in C/C++ if you want to include a backslash \ in a string literal you need to write a double backslash \\ !
-        //io.Fonts->AddFontDefault();
-        //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Roboto-Medium.ttf", 16.0f);
-        //io.Fonts->AddFontFromFileTTF("../../misc/fonts/Cousine-Regular.ttf", 15.0f);
-        //io.Fonts->AddFontFromFileTTF("../../misc/fonts/DroidSans.ttf", 16.0f);
-        //io.Fonts->AddFontFromFileTTF("../../misc/fonts/ProggyTiny.ttf", 10.0f);
-        //ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, NULL, io.Fonts->GetGlyphRangesJapanese());
-        //IM_ASSERT(font != NULL);
-
-        // Upload Fonts
-        {
-            // Prepare to create a temporary command pool.
-            VkCommandPool pool;
-            VkCommandPoolCreateInfo poolCreateInfo = {};
-            poolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-            poolCreateInfo.queueFamilyIndex = vk->getDevice()->queueData.graphics;
-            poolCreateInfo.flags = 0;
-
-            // Create the pool
-            if (vkCreateCommandPool(vk->getDevice()->logical, &poolCreateInfo, nullptr, &pool) != VK_SUCCESS)
-                throw std::runtime_error("Unable to allocate a temporary command pool");
-
-            VkCommandBuffer buffer = VkTools::createTempCommandBuffer(pool, vk->getDevice()->logical);
-
-            ImGui_ImplVulkan_CreateFontsTexture(buffer);
-
-            VkSubmitInfo end_info = {};
-            end_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-            end_info.commandBufferCount = 1;
-            end_info.pCommandBuffers = &buffer;
-
-            VkTools::executeAndDeleteTempBuffer(buffer, pool, vk->getDevice()->graphicsQueue, vk->getDevice()->logical);
-
-            ImGui_ImplVulkan_DestroyFontUploadObjects();
-        }
-
-        /*
-		moduleManager.PushModule(new Log());
-		moduleManager.PushModule(new EventSystem::ShadowEventManager());
-		moduleManager.PushModule(new SDLPlatform::SDLModule());
-		moduleManager.PushModule(new Rendering::Renderer());
-
-		moduleManager.PushModule(new Assets::AssetManager());
-
-		if(!no_gui)
-		moduleManager.PushModule(new DebugGui::ImGuiModule());
-		
-		moduleManager.PushModule(new InputSystem::ShadowActionSystem());
-		//
-		moduleManager.PushModule(new EntitySystem::EntitySystem());
-        */
 	}
 
 	void ShadowApplication::Start()
 	{
-        CATCH(object.createSingleRenderer(Geo::MeshType::Cube, glm::vec3(-1, 0, -1), glm::vec3(0.5));)
-
-        // Create the camera
-        Camera camera {};
-        camera.init(45, 1280, 720, 0.1, 10000);
-        camera.setPosition(glm::vec3(0, 0, 4));
-
         SDL_Event event;
 		while (running)
 		{
             while (SDL_PollEvent(&event)) {  // poll until all events are handled!
-                ImGui_ImplSDL2_ProcessEvent(&event);
+                moduleManager.Event(&event);
                 if (event.type == SDL_QUIT)
                     running = false;
             }
 
-            object.setRotation(glm::rotate(object.getRotation(), (float) 0.5, glm::vec3(1, 0, 0)));
+            moduleManager.Update();
+            moduleManager.PreRender();
 
             VulkanManager::getInstance()->startDraw();
-            ImGui_ImplVulkan_NewFrame();
-            ImGui_ImplSDL2_NewFrame();
-            ImGui::NewFrame();
-
-            /** START OF RENDER AREA  */
-            /** PUT CODE HERE TO MAKE IT SHOW ON SCREEN */
-            CATCH(object.updateUniforms(camera);)
-            CATCH(object.draw();)
-
-            bool showDemo = true;
-            if (showDemo)
-                ImGui::ShowDemoWindow(&showDemo);
-
             moduleManager.Render();
-            /** END OF RENDER AREA */
-            /** CODE AFTER HERE WILL NOT BE SHOWN ON SCREEN */
 
-            ImGui::Render();
-            ImGuiIO& io = ImGui::GetIO(); (void)io;
-
-            ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), VulkanManager::getInstance()->getCurrentCommandBuffer());
-
-            // Update and Render additional Platform Windows
-            if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
-            {
-                ImGui::UpdatePlatformWindows();
-                ImGui::RenderPlatformWindowsDefault();
-            }
+            moduleManager.LateRender();
             VulkanManager::getInstance()->endDraw();
 
-            Time::UpdateTime();
+            moduleManager.AfterFrameEnd();
 		}
 
-        ImGui_ImplVulkan_Shutdown();
-        ImGui_ImplSDL2_Shutdown();
-        ImGui::DestroyContext();
-
-        SDL_DestroyWindow(window_->sdlWindowPtr);
-        SDL_Quit();
+        moduleManager.Destroy();
 
         delete gameLib;
 	}

--- a/projs/test-game/inc/GameModule.h
+++ b/projs/test-game/inc/GameModule.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <SDL_events.h>
 #include "core/Module.h"
 
 class GameModule : public ShadowEngine::Module {
@@ -14,10 +15,16 @@ public:
 
     void Update() override;
 
+    void PreRender() override;
+
     void Render() override;
 
     void LateRender() override;
 
     void AfterFrameEnd() override;
+
+    void Destroy() override;
+
+    void Event(SDL_Event*) override;
 
 };

--- a/projs/test-game/src/GameModule.cpp
+++ b/projs/test-game/src/GameModule.cpp
@@ -1,16 +1,125 @@
 #include <GameModule.h>
-#include <iostream>
 #include "imgui.h"
+#include "spdlog/spdlog.h"
+#include "vlkx/render/geometry/SingleRenderer.h"
+#include "imgui_impl_vulkan.h"
+#include "core/ShadowApplication.h"
+#include "core/SDL2Module.h"
+#include "imgui_impl_sdl.h"
 #include "core/Time.h"
 
-void GameModule::PreInit() { std::cout << "what?" << std::endl; }
 
-void GameModule::Init() {}
+#define CATCH(x) \
+    try { x } catch (std::exception& e) { spdlog::error(e.what()); exit(0); }
 
-void GameModule::Update() {}
+// Create the renderer
+SingleRenderer object;
+
+// Create the camera
+Camera camera;
+
+void GameModule::PreInit() { spdlog::info("Game Module loading.."); }
+
+void GameModule::Init() {
+
+    auto sdl2module = ShadowEngine::ShadowApplication::Get().GetModuleManager().GetModuleByType<ShadowEngine::SDL2Module>();
+
+    CATCH(VulkanManager::getInstance()->initVulkan(sdl2module->_window->sdlWindowPtr);)
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
+    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
+
+    // Setup Dear ImGui style
+    ImGui::StyleColorsDark();
+    VkDescriptorPool imGuiPool;
+    VulkanManager* vk = VulkanManager::getInstance();
+    VkDescriptorPoolSize pool_sizes[] =
+            {
+                    { VK_DESCRIPTOR_TYPE_SAMPLER, 1000 },
+                    { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1000 },
+                    { VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1000 },
+                    { VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1000 },
+                    { VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1000 },
+                    { VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1000 },
+                    { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1000 },
+                    { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1000 },
+                    { VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1000 },
+                    { VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1000 },
+                    { VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1000 }
+            };
+
+    VkDescriptorPoolCreateInfo pool_info = {};
+    pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    pool_info.maxSets = 1000 * IM_ARRAYSIZE(pool_sizes);
+    pool_info.poolSizeCount = (uint32_t)IM_ARRAYSIZE(pool_sizes);
+    pool_info.pPoolSizes = pool_sizes;
+    vkCreateDescriptorPool(vk->getDevice()->logical, &pool_info, VK_NULL_HANDLE, &imGuiPool);
+
+    // Setup Platform/Renderer backends
+    ImGui_ImplSDL2_InitForVulkan(sdl2module->_window->sdlWindowPtr);
+    ImGui_ImplVulkan_InitInfo init_info = {};
+    init_info.Instance = vk->getVulkan();
+    init_info.PhysicalDevice = vk->getDevice()->physical;
+    init_info.Device = vk->getDevice()->logical;
+    init_info.QueueFamily = vk->getDevice()->queueData.graphics;
+    init_info.Queue = vk->getDevice()->graphicsQueue;
+    init_info.PipelineCache = VK_NULL_HANDLE;
+    init_info.DescriptorPool = imGuiPool;
+    init_info.Subpass = 0;
+    init_info.MinImageCount = vk->getSwapchain()->images.size();
+    init_info.ImageCount = vk->getSwapchain()->images.size();
+    init_info.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+    init_info.Allocator = VK_NULL_HANDLE;
+    init_info.CheckVkResultFn = nullptr;
+    ImGui_ImplVulkan_Init(&init_info, vk->getRenderPass()->pass);
+
+    // Upload Fonts
+    {
+        // Prepare to create a temporary command pool.
+        VkCommandPool pool;
+        VkCommandPoolCreateInfo poolCreateInfo = {};
+        poolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+        poolCreateInfo.queueFamilyIndex = vk->getDevice()->queueData.graphics;
+        poolCreateInfo.flags = 0;
+
+        // Create the pool
+        if (vkCreateCommandPool(vk->getDevice()->logical, &poolCreateInfo, nullptr, &pool) != VK_SUCCESS)
+            throw std::runtime_error("Unable to allocate a temporary command pool");
+
+        VkCommandBuffer buffer = VkTools::createTempCommandBuffer(pool, vk->getDevice()->logical);
+
+        ImGui_ImplVulkan_CreateFontsTexture(buffer);
+
+        VkSubmitInfo end_info = {};
+        end_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        end_info.commandBufferCount = 1;
+        end_info.pCommandBuffers = &buffer;
+
+        VkTools::executeAndDeleteTempBuffer(buffer, pool, vk->getDevice()->graphicsQueue, vk->getDevice()->logical);
+
+        ImGui_ImplVulkan_DestroyFontUploadObjects();
+    }
+
+    CATCH(object.createSingleRenderer(Geo::MeshType::Cube, glm::vec3(-1, 0, -1), glm::vec3(0.5));)
+    camera.init(45, 1280, 720, 0.1, 10000);
+    camera.setPosition(glm::vec3(0, 0, 4));
+}
+
+void GameModule::Update() {
+    object.setRotation(glm::rotate(object.getRotation(), (float) 0.5, glm::vec3(1, 0, 0)));
+}
+
+void GameModule::PreRender() {
+    ImGui_ImplVulkan_NewFrame();
+    ImGui_ImplSDL2_NewFrame();
+    ImGui::NewFrame();
+}
 
 void GameModule::Render() {
-
     bool active = true;
     ImGui::Begin("Game module window", &active, ImGuiWindowFlags_MenuBar);
 
@@ -18,9 +127,39 @@ void GameModule::Render() {
 
     ImGui::End();
 
+    CATCH(object.updateUniforms(camera);)
+    CATCH(object.draw();)
+
+    bool showDemo = true;
+    if (showDemo)
+        ImGui::ShowDemoWindow(&showDemo);
 
 }
 
-void GameModule::LateRender() {}
+void GameModule::LateRender() {
+    ImGui::Render();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
 
-void GameModule::AfterFrameEnd() {}
+    ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), VulkanManager::getInstance()->getCurrentCommandBuffer());
+
+    // Update and Render additional Platform Windows
+    if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+    {
+        ImGui::UpdatePlatformWindows();
+        ImGui::RenderPlatformWindowsDefault();
+    }
+}
+
+void GameModule::AfterFrameEnd() {
+    Time::UpdateTime();
+}
+
+void GameModule::Destroy() {
+    ImGui_ImplVulkan_Shutdown();
+    ImGui_ImplSDL2_Shutdown();
+    ImGui::DestroyContext();
+}
+
+void GameModule::Event(SDL_Event *) {
+
+}


### PR DESCRIPTION
Export shared_ptr<GameModule> from the DLL, and store the dylib in a wider scope.

Additionally, all modules are shared_ptr to prevent the Game Module from going out of scope.

Additionally, the Module needs to be pure virtual.